### PR TITLE
Update calibrate_lens_shading to set geq to max

### DIFF
--- a/src/labthings_picamera2/thing.py
+++ b/src/labthings_picamera2/thing.py
@@ -868,6 +868,7 @@ class StreamingPiCamera2(Thing):
         one. This uses the camera's "tuning" file to correct the preview and
         the processed images. It should not affect raw images.
         """
+        self.set_static_green_equalisation()
         with self.picamera(pause_stream=True) as cam:
             L, Cr, Cb = recalibrate_utils.lst_from_camera(cam)
             recalibrate_utils.set_static_lst(self.tuning, L, Cr, Cb)


### PR DESCRIPTION
Update calibrate_lens_shading to set geq to max by calling self.set_static_green_equalisation()

Tested on my microscope, sets the value as expected